### PR TITLE
Add Pivot Table Support (+ refactor some other features)

### DIFF
--- a/dist/js/field.js
+++ b/dist/js/field.js
@@ -327,7 +327,7 @@ var render = function() {
   var _h = _vm.$createElement
   var _c = _vm._self._c || _h
   return _c("div", { staticClass: "flex items-center" }, [
-    _vm.field.last != _vm.resourceId
+    !_vm.field.last
       ? _c(
           "button",
           {
@@ -366,7 +366,7 @@ var render = function() {
         )
       : _vm._e(),
     _vm._v(" "),
-    _vm.field.first != _vm.resourceId
+    !_vm.field.first
       ? _c(
           "button",
           {

--- a/dist/js/field.js
+++ b/dist/js/field.js
@@ -304,9 +304,11 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 
       Nova.request().post("/nova-vendor/michielkempen/nova-order-field/" + this.resourceName, {
         direction: direction,
-        field: this.field.attribute,
         resource: this.resourceName,
-        resourceId: this.resourceId
+        resourceId: this.resourceId,
+        viaResource: this.field.viaResource,
+        viaResourceId: this.field.viaResourceId,
+        viaRelationship: this.field.viaRelationship
       }).then(function () {
         _this.$toasted.show(_this.__("The new order has been set!"), {
           type: "success"

--- a/resources/js/components/IndexField.vue
+++ b/resources/js/components/IndexField.vue
@@ -63,9 +63,11 @@ export default {
           `/nova-vendor/michielkempen/nova-order-field/${this.resourceName}`,
           {
             direction: direction,
-            field: this.field.attribute,
             resource: this.resourceName,
-            resourceId: this.resourceId
+            resourceId: this.resourceId,
+            viaResource: this.field.viaResource || null,
+            viaResourceId: this.field.viaResourceId || null,
+            viaRelationship: this.field.viaRelationship || null
           }
         )
         .then(() => {

--- a/resources/js/components/IndexField.vue
+++ b/resources/js/components/IndexField.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex items-center">
     <button
-      v-if="field.last != resourceId"
+      v-if="!field.last"
       @click="reorderResource('down')"
       class="cursor-pointer text-70 hover:text-primary mr-3"
     >
@@ -22,7 +22,7 @@
       </svg>
     </button>
     <button
-      v-if="field.first != resourceId"
+      v-if="!field.first"
       @click="reorderResource('up')"
       class="cursor-pointer text-70 hover:text-primary"
     >

--- a/src/HasOrderablePivot.php
+++ b/src/HasOrderablePivot.php
@@ -32,7 +32,7 @@ trait HasOrderablePivot
      * @param  NovaRequest  $request
      * @return null|\Illuminate\Database\Eloquent\Model
      */
-    protected static function orderedManyPivotModel(NovaRequest $request)
+    public static function orderedManyPivotModel(NovaRequest $request)
     {
         if(!$request->viaRelationship()) {
             return;

--- a/src/HasOrderablePivot.php
+++ b/src/HasOrderablePivot.php
@@ -20,6 +20,8 @@ trait HasOrderablePivot
     {
         $attribute = static::modelOrderByFieldAttribute($pivot);
 
+        $query->select(static::newModel()->getTable() . '.*');
+
         return static::orderedIndexQuery(
             $query,
             $attribute ? $pivot->qualifyColumn($attribute) : null

--- a/src/HasOrderablePivot.php
+++ b/src/HasOrderablePivot.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Spatie\EloquentSortable\Sortable;
 
-trait OrderablePivot
+trait HasOrderablePivot
 {
     /**
      * Build an "index" query for the given related resource.
@@ -20,13 +20,10 @@ trait OrderablePivot
     {
         $attribute = static::modelOrderByFieldAttribute($pivot);
 
-        if(!$attribute) {
-            return $query;
-        }
-
-        $query->orderBy($pivot->qualifyColumn($attribute));
-
-        return $query;
+        return static::orderedIndexQuery(
+            $query,
+            $attribute ? $pivot->qualifyColumn($attribute) : null
+        );
     }
 
     /**

--- a/src/OrderField.php
+++ b/src/OrderField.php
@@ -48,8 +48,18 @@ class OrderField extends Field
         );
 
         if($pivot = $this->shouldResolveOnPivot($request, $resourceClass)) {
-            return data_get($pivot, $resourceClass::modelOrderByFieldAttribute($pivot));
+            $attribute = $resourceClass::modelOrderByFieldAttribute($pivot);
+
+            $this->withMeta([
+                'viaResource' => $request->viaResource,
+                'viaResourceId' => $request->viaResourceId,
+                'viaRelationship' => $request->viaRelationship,
+            ]);
+
+            return data_get($pivot, $attribute);
         }
+
+        $attribute = $resourceClass::modelOrderByFieldAttribute($resource);
 
         return data_get($resource, $attribute);
     }

--- a/src/OrderField.php
+++ b/src/OrderField.php
@@ -2,7 +2,9 @@
 
 namespace MichielKempen\NovaOrderField;
 
+use Laravel\Nova\Resource;
 use Laravel\Nova\Fields\Field;
+use Laravel\Nova\Http\Requests\NovaRequest;
 
 class OrderField extends Field
 {
@@ -37,6 +39,22 @@ class OrderField extends Field
      */
     protected function resolveAttribute($resource, $attribute)
     {
+        $request = resolve(NovaRequest::class);
+
+        if(!is_a($resource, Resource::class)) {
+            $resourceClass = $request->resource();
+        } else {
+            $resourceClass = get_class($resource);
+        }
+
+        if($pivot = $this->shouldResolveOnPivot($request, $resourceClass)) {
+            return $this->resolvePivotAttribute($pivot, $resourceClass);
+        }
+
+        // TODO : first & last should not be computed here because
+        // this will perform 2 queries for each line displayed
+        // in the Index Table.
+
         $first = $resource->buildSortQuery()->ordered()->first();
         $last = $resource->buildSortQuery()->ordered('desc')->first();
 
@@ -46,5 +64,46 @@ class OrderField extends Field
         ]);
 
         return data_get($resource, $attribute);
+    }
+
+    /**
+     * Resolve the given attribute from the given resource.
+     *
+     * @param  NovaRequest  $request
+     * @param  string  $resource
+     * @return bool|Resource
+     */
+    protected function shouldResolveOnPivot(NovaRequest $request, $resource)
+    {
+        if($resource::canQueryPivotOrder() && $pivot = $resource::orderedManyPivotModel($request)) {
+            return $pivot;
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve the given attribute from the given resource.
+     *
+     * @param  mixed  $pivot
+     * @param  string  $resource
+     * @return mixed
+     */
+    protected function resolvePivotAttribute($pivot, $resource)
+    {
+        // TODO : first & last should not be computed here because
+        // this will perform 2 queries for each line displayed
+        // in the Index Table.
+        // Alos, they don't work correctly on pivots right now.
+
+        $first = $pivot->buildSortQuery()->ordered()->first();
+        $last = $pivot->buildSortQuery()->ordered('desc')->first();
+
+        $this->withMeta([
+            'first' => is_null($first) ? null : $first->id,
+            'last' => is_null($last) ? null : $last->id,
+        ]);
+
+        return data_get($pivot, $resource::modelOrderByFieldAttribute($pivot));
     }
 }

--- a/src/Orderable.php
+++ b/src/Orderable.php
@@ -16,6 +16,13 @@ trait Orderable
     public static $defaultOrderField;
 
     /**
+     * The first & last resourceId of the excecuted indexQuery
+     *
+     * @var null|array
+     */
+    public static $orderedExtrema;
+
+    /**
      * Build an "index" query for the given resource.
      *
      * @param  NovaRequest  $request
@@ -51,9 +58,27 @@ trait Orderable
             abort(500, static::$model . ' should implement the ' . Sortable::class . ' interface and define a valid order_column_name.');
         }
 
+        static::$orderedExtrema = [
+            static::applyQueryOrder($query, $attribute)->first(),
+            static::applyQueryOrder($query, $attribute, 'desc')->first(),
+        ];
+
+        return static::applyQueryOrder($query, $attribute);
+    }
+
+    /**
+     * Clear any previously set order & apply given orderBy statement
+     *
+     * @param  Builder  $query
+     * @param  string  $attribute
+     * @param  string  $direction
+     * @return Builder
+     */
+    public static function applyQueryOrder($query, $attribute, $direction = 'asc')
+    {
         $query->getQuery()->orders = [];
 
-        return $query->orderBy($attribute);
+        return $query->orderBy($attribute, $direction);
     }
 
     /**

--- a/src/Orderable.php
+++ b/src/Orderable.php
@@ -38,8 +38,8 @@ trait Orderable
     {
         $query->getQuery()->orders = [];
 
-        if($relationship = static::orderedManyRelationship($request)) {
-            return static::orderedPivotIndexQuery($request, $query, $relationship);
+        if($pivot = static::orderedManyPivotModel($request)) {
+            return static::orderedPivotIndexQuery($request, $query, $pivot);
         }
 
         return $query->orderBy(static::orderByFieldAttribute($request));
@@ -50,15 +50,11 @@ trait Orderable
      *
      * @param  NovaRequest  $request
      * @param  Builder  $query
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relationship
+     * @param  \Illuminate\Database\Eloquent\Model  $pivot
      * @return Builder
      */
-    public static function orderedPivotIndexQuery(NovaRequest $request, $query, $relationship)
+    public static function orderedPivotIndexQuery(NovaRequest $request, $query, $pivot)
     {
-        $pivot = $relationship->getPivotClass();
-
-        $pivot = new $pivot;
-
         $attribute = static::modelOrderByFieldAttribute($pivot);
 
         if(!$attribute) {
@@ -74,9 +70,9 @@ trait Orderable
      * Get the requested resource relationship
      *
      * @param  NovaRequest  $request
-     * @return null|\Illuminate\Database\Eloquent\Relations\Relation
+     * @return null|\Illuminate\Database\Eloquent\Model
      */
-    protected static function orderedManyRelationship(NovaRequest $request)
+    protected static function orderedManyPivotModel(NovaRequest $request)
     {
         if(!$request->viaRelationship()) {
             return;
@@ -90,7 +86,13 @@ trait Orderable
             return;
         }
 
-        return $relation;
+        $pivot = $relationship->getPivotClass();
+
+        if(!($model = new $pivot) instanceof Sortable) {
+            return;
+        }
+
+        return $model;
     }
 
     /**

--- a/src/Orderable.php
+++ b/src/Orderable.php
@@ -97,7 +97,7 @@ trait Orderable
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return null|string
      */
-    protected static function modelOrderByFieldAttribute($model)
+    public static function modelOrderByFieldAttribute($model)
     {
         if (!$model instanceof Sortable) {
             return;

--- a/src/Orderable.php
+++ b/src/Orderable.php
@@ -80,9 +80,9 @@ trait Orderable
 
         $resource = $request->viaResource();
 
-        $relation = $resource::newModel()->{$request->viaRelationship}();
+        $relationship = $resource::newModel()->{$request->viaRelationship}();
 
-        if(!$relation || !$relation->getPivotClass()) {
+        if(!$relationship || !$relationship->getPivotClass()) {
             return;
         }
 

--- a/src/Orderable.php
+++ b/src/Orderable.php
@@ -4,9 +4,29 @@ namespace MichielKempen\NovaOrderField;
 
 use Illuminate\Database\Eloquent\Builder;
 use Laravel\Nova\Http\Requests\NovaRequest;
+use Spatie\EloquentSortable\Sortable;
 
 trait Orderable
 {
+    /**
+     * The user-defined OrderFieldAttribute
+     *
+     * @var string
+     */
+    public static $defaultOrderField;
+
+    /**
+     * Find the orderByField for current request
+     *
+     * @param  NovaRequest  $request
+     * @return string
+     */
+    public static function orderByFieldAttribute(NovaRequest $request)
+    {
+        return static::$defaultOrderField
+            ?? static::modelOrderByFieldAttribute(static::newModel());
+    }
+    
     /**
      * Build an "index" query for the given resource.
      *
@@ -17,6 +37,74 @@ trait Orderable
     public static function indexQuery(NovaRequest $request, $query)
     {
         $query->getQuery()->orders = [];
-        return $query->orderBy(static::$defaultOrderField);
+
+        if($relationship = static::orderedManyRelationship($request)) {
+            return static::orderedPivotIndexQuery($request, $query, $relationship);
+        }
+
+        return $query->orderBy(static::orderByFieldAttribute($request));
+    }
+
+    /**
+     * Build an "index" query for the given related resource.
+     *
+     * @param  NovaRequest  $request
+     * @param  Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relationship
+     * @return Builder
+     */
+    public static function orderedPivotIndexQuery(NovaRequest $request, $query, $relationship)
+    {
+        $pivot = $relationship->getPivotClass();
+
+        $pivot = new $pivot;
+
+        $attribute = static::modelOrderByFieldAttribute($pivot);
+
+        if(!$attribute) {
+            return $query;
+        }
+
+        $query->orderBy($pivot->qualifyColumn($attribute));
+
+        return $query;
+    }
+
+    /**
+     * Get the requested resource relationship
+     *
+     * @param  NovaRequest  $request
+     * @return null|\Illuminate\Database\Eloquent\Relations\Relation
+     */
+    protected static function orderedManyRelationship(NovaRequest $request)
+    {
+        if(!$request->viaRelationship()) {
+            return;
+        }
+
+        $resource = $request->viaResource();
+
+        $relation = $resource::newModel()->{$request->viaRelationship}();
+
+        if(!$relation || !$relation->getPivotClass()) {
+            return;
+        }
+
+        return $relation;
+    }
+
+    /**
+     * Extract the order_column_name from a Sortable Model
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return null|string
+     */
+    protected static function modelOrderByFieldAttribute($model)
+    {
+        if (!$model instanceof Sortable) {
+            abort(500, get_class($model) . ' should implement the ' . Sortable::class . ' interface.');
+        }
+
+        return $model->sortable['order_column_name'] ?? null;
     }
 }

--- a/src/OrderablePivot.php
+++ b/src/OrderablePivot.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace MichielKempen\NovaOrderField;
+
+use Illuminate\Database\Eloquent\Builder;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Spatie\EloquentSortable\Sortable;
+
+trait OrderablePivot
+{
+    /**
+     * Build an "index" query for the given related resource.
+     *
+     * @param  NovaRequest  $request
+     * @param  Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Model  $pivot
+     * @return Builder
+     */
+    public static function orderedPivotIndexQuery(NovaRequest $request, $query, $pivot)
+    {
+        $attribute = static::modelOrderByFieldAttribute($pivot);
+
+        if(!$attribute) {
+            return $query;
+        }
+
+        $query->orderBy($pivot->qualifyColumn($attribute));
+
+        return $query;
+    }
+
+    /**
+     * Get the requested resource relationship
+     *
+     * @param  NovaRequest  $request
+     * @return null|\Illuminate\Database\Eloquent\Model
+     */
+    protected static function orderedManyPivotModel(NovaRequest $request)
+    {
+        if(!$request->viaRelationship()) {
+            return;
+        }
+
+        $resource = $request->viaResource();
+
+        $relationship = $resource::newModel()->{$request->viaRelationship}();
+
+        if(!$relationship || !$relationship->getPivotClass()) {
+            return;
+        }
+
+        $pivot = $relationship->getPivotClass();
+
+        if(!($model = new $pivot) instanceof Sortable) {
+            return;
+        }
+
+        return $model;
+    }
+}


### PR DESCRIPTION
Hi there,

**Disclaimer:** Sorry for the long post. It mostly contains a self-explanatory tutorial. Don't worry, I tested every feature and took care of writing clean code. If you don't have the time to read it all, I hope you'll consider to merge it anyway.

We really needed this package to work with pivot tables, so I decided to give it a go. It turned out to be a little bit tricky with the existing code base, I hope you don't mind if I refactored most of it. Don't worry, this PR should not break backward compatibility.

First of all, I'd like to mention that the implementation of Ordered Pivot Tables would have been much easier if Nova supported custom Resources for pivot tables, which is unfortunately not the case. Instead, we'll have to apply the `OrderField` on the related (target) resource, which does not make much sense. It could be a good idea to open an issue on Nova's repository requesting to replace the current "invokable" class with a proper Resource for Pivot Models.

## How to apply ordering on Pivot Tables

In the following steps, we'll consider the following example structure: 

```
Player
 - id
 - ...

Card
 - id
 - ...

CardPlayer
 - id
 - player_id
 - card_id
 - order
 - ...
```

**1.** First, you'll have to create a [Custom Pivot Model](https://laravel.com/docs/6.x/eloquent-relationships#defining-custom-intermediate-table-models) for our `card_player` pivot table then implement Spatie's `Sortable` interface and `SortableTrait` on it:

```php
namespace App;

use Illuminate\Database\Eloquent\Relations\Pivot;
use Spatie\EloquentSortable\Sortable;
use Spatie\EloquentSortable\SortableTrait;

class CardPlayer extends Pivot implements Sortable
{
    use SortableTrait;

    /*
     * Determine the column name of the order column.
     */
    public $sortable = [
        'order_column_name' => 'order',
        'sort_when_creating' => true,
    ];

    /*
     * Group cards per player, making it possible to restart ordering
     * from index 1 for each player.
     */
    public function buildSortQuery()
    {
        return static::query()->where('player_id', $this->player_id);
    }
}
```

Please note the `buildSortQuery` method, which is really important here. Without it, the pivot table would have one single ordering index instead of having a dedicated "counter" for each player.

**2.** Do not forget to add our new Pivot Model to the Player's `cards()` relationship:

```php
    public function cards()
    {
        return $this->belongsToMany(\App\Card::class)
            ->using(\App\CardPlayer::class)
            ->withPivot(['id', 'order']);
    }
```

Using the relationship's `withPivot` method, we'll make sure the pivot table's `id` and `order` columns are always queried. Of course, you could add other columns if needed, but we'll need at least those two (or whatever you named them) to get the nova-order-field package to work.

**3.** Now comes the important part: adding the `OrderField` to the resource in order to display the "up/down" buttons on the Index Table.

Please keep in mind that we're trying to apply this new field on the Pivot Model, not on the actual resource we're actually adding it to. I know, this is weird, but we don't really have a choice without the dedicated Pivot Resources I was talking about earlier.

Since the Index Table will be displayed using Nova's `viaRelationship`, we should only add the `OrderField` to the target resource's fields when we're querying them in the context of the `cards` relationship. Otherwise, the "up/down" buttons will always be displayed, even when the Pivot table is not involved. To do so, here's how the `Card` Resource's `fields` method should look like: 

```php
    public function fields(Request $request)
    {
        $fields = [
            ID::make()->sortable()->hideFromIndex(),
            // ...
        ];

        if($request->viaResource === 'players' && $request->viaRelationship === 'cards') {
            array_unshift($fields, OrderField::make('My Custom Order'));
        }

        return $fields;
    }
```

The package will be able to use Nova's `viaRelationship` data in order to automatically check if the ordering column is located on the pivot table or on the target resource's table. No further configuration should be needed.

If there's only one relationship targeting the `Card` resource, we could shorten our `OrderField` condition as follows:

```php
if($request->viaRelationship()) {
    array_unshift($fields, OrderField::make('My Custom Order'));
}
```

When the target Resource also has its own order column (meaning the pivot table most probably overrides the "default" order), there's no need to extract the `OrderField` in a condition. Instead, we'll be able to define the fields in a much simpler way:

```php
    public function fields(Request $request)
    {
        return [
            ID::make()->sortable()->hideFromIndex(),
            OrderField::make('My Custom Order'),
            // ...
        ];
    }
```

In this scenario, the package will be able to recognize the table it should apply the order on on its own: it will always prefer the pivot table if there is one, otherwise it will use the target resource's table instead.

## Other updates

- The package now automatically retrieves the model's `order_column_name` configuration (from Spatie's `Spatie\EloquentSortable\Sortable` trait). There is no need to declare the `static::$defaultOrderField` attribute on the resource anymore.
- It is therefore also not useful to add an attribute name when adding the field using `OrderField::make('My custom order')` since the package will not use it anymore. Instead, we'll also retrieve the correct column name directly in the model's `$sortable` configuration.
- We also improved the way the `first` and `last` rows are retrieved (which are used for hiding or displaying the up/down buttons when needed). Instead of fetching the IDs from the database each time a row is displayed, the package now uses Nova's `indexQuery` (the same one as Nova used to display the original table) in order to get those IDs only once.

---

Please note that I did not have the time to update the `README.md` file. It might be a good idea to explain how to achieve Pivot Table Ordering somewhere in it, maybe using the above explanation.

This PR closes issue #13.

Thank you!