### PR TITLE
Remove defaultOrderField from Orderable

### DIFF
--- a/src/Orderable.php
+++ b/src/Orderable.php
@@ -9,13 +9,6 @@ use Spatie\EloquentSortable\Sortable;
 trait Orderable
 {
     /**
-     * The user-defined OrderFieldAttribute
-     *
-     * @var string
-     */
-    public static $defaultOrderField;
-
-    /**
      * The first & last resourceId of the excecuted indexQuery
      *
      * @var null|array


### PR DESCRIPTION
This PR removed the `$defaultOrderField` variable that the user should define themselfs in the Resource class. The following exception is thown with this defined in the trait as well:

`App\Nova\XXXXXX and MichielKempen\NovaOrderField\Orderable define the same property ($defaultOrderField) in the composition of App\Nova\XXXXXX. However, the definition differs and is considered incompatible. Class was composed`