### PR TITLE
Assume the default order_column_name

### DIFF
--- a/src/Orderable.php
+++ b/src/Orderable.php
@@ -122,6 +122,6 @@ trait Orderable
             return;
         }
 
-        return $model->sortable['order_column_name'] ?? null;
+        return $model->sortable['order_column_name'] ?? 'order_column';
     }
 }


### PR DESCRIPTION
Spatie uses 'order_column' as the default order_column_name, so I think it makes sense to assume the default to be 'order_column' unless explicitly set.